### PR TITLE
Add isset() check to min_date key

### DIFF
--- a/includes/DateTimePicker.php
+++ b/includes/DateTimePicker.php
@@ -277,7 +277,7 @@ if ( ! class_exists( 'DateTimePicker' ) ) {
 			// setup variables
 			$min_time = $opts['minTime'];
 			$max_time = $opts['maxTime'];
-			$min_date = $opts['min_date'];
+			$min_date = isset( $opts['min_date'] ) ? $opts['min_date'] : null;
 			$step     = $opts['step'];
 			$allowed  = $opts['allowed_times'];
 			$offset   = isset( $opts['offset'] ) ? intval( $opts['offset'] ) : 0;


### PR DESCRIPTION
if $opts['min_date'] isn't set, a PHP error is thrown on line 280.  Originally, this line wasn't being checked.